### PR TITLE
fix: refactor test to follow an ordered execution

### DIFF
--- a/shellx-carvel/README.md
+++ b/shellx-carvel/README.md
@@ -1,15 +1,19 @@
 ## Golang scripting to manage releases
 - This codebase showcases use of Golang to script a project's release
 - Note: _Release management is done by Carvel_
-- Motivation:
+
+- ## Motivation:
   - Goodness of bash coupled with correctness of Golang
   - Granular error handling
   - 100% unit tested
   - Modular code base
   - Reduced bash & make spaghetti
 
-## Usage
+## Test
 - `make`
+
+## Usage
+TODO
 
 ### References
 - https://github.com/gohugoio/hugo/blob/master/magefile.go

--- a/shellx-carvel/bundle.go
+++ b/shellx-carvel/bundle.go
@@ -2,8 +2,13 @@ package shellx_carvel
 
 // This file provides functions that cater to Carvel related packaging
 
+// TODO: Should these be environment variables?
+func getDefaultCarvelPackagingDir() string {
+	return "packaging"
+}
+
 func getDefaultSourceDir() string {
-	return "package/source"
+	return getDefaultCarvelPackagingDir() + "/source"
 }
 
 func getDefaultAppConfigDir() string {

--- a/shellx-carvel/bundle_test.go
+++ b/shellx-carvel/bundle_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func tryAppBundleCreateAndPublish(t *testing.T) {
-	sourceDir := "tmp/source"
+	sourceDir := "tmp/packaging/source"
 	configDir := sourceDir + "/config"
 	imgpkgDir := sourceDir + "/.imgpkg"
 

--- a/shellx-carvel/carvel.go
+++ b/shellx-carvel/carvel.go
@@ -18,19 +18,3 @@ func installCarvelCLIs() error {
 	}
 	return nil
 }
-
-func installKind() error {
-	if err := mkdir(binPathKind); err != nil {
-		return err
-	}
-	if isErr(whichKind()) {
-		installPath := "$BIN_PATH_KIND/kind"
-		if err := curl("https://kind.sigs.k8s.io/dl/$KIND_VERSION/kind-$GOOS-$GOARCH", "-Lo", installPath); err != nil {
-			return err
-		}
-		if err := chmod("+x", installPath); err != nil {
-			return err
-		}
-	}
-	return nil
-}

--- a/shellx-carvel/carvel_test.go
+++ b/shellx-carvel/carvel_test.go
@@ -1,17 +1,9 @@
 package shellx_carvel
 
-import (
-	"testing"
-)
+import "testing"
 
 func tryInstallCarvelCLIs(t *testing.T) {
 	requireNoErr(t, installCarvelCLIs())
 	requireNoErr(t, ls(EnvBinPathCarvel))
 	requireTrue(t, isNoErr(whichKbld(), whichYtt(), whichImgpkg()))
-}
-
-func tryInstallKindCLI(t *testing.T) {
-	requireNoErr(t, installKind())
-	requireNoErr(t, ls(EnvBinPathKind))
-	requireTrue(t, isNoErr(whichKind()))
 }

--- a/shellx-carvel/carvel_workflow_test.go
+++ b/shellx-carvel/carvel_workflow_test.go
@@ -5,6 +5,7 @@ import "testing"
 func TestReleaseCarvelPackage(t *testing.T) {
 	tryInstallCarvelCLIs(t)
 	tryInstallKindCLI(t)
+	trySetupRegistryAsLocalDockerContainer(t)
 	tryAppBundleCreateAndPublish(t)
 	tryPackageRelease(t)
 }

--- a/shellx-carvel/docker_test.go
+++ b/shellx-carvel/docker_test.go
@@ -2,6 +2,6 @@ package shellx_carvel
 
 import "testing"
 
-func TestSetupRegistryAsLocalDockerContainer(t *testing.T) {
+func trySetupRegistryAsLocalDockerContainer(t *testing.T) {
 	requireNoErr(t, setupRegistryAsLocalDockerContainer())
 }

--- a/shellx-carvel/kind.go
+++ b/shellx-carvel/kind.go
@@ -1,0 +1,17 @@
+package shellx_carvel
+
+func installKindCLI() error {
+	if err := mkdir(binPathKind); err != nil {
+		return err
+	}
+	if isErr(whichKind()) {
+		installPath := "$BIN_PATH_KIND/kind"
+		if err := curl("https://kind.sigs.k8s.io/dl/$KIND_VERSION/kind-$GOOS-$GOARCH", "-Lo", installPath); err != nil {
+			return err
+		}
+		if err := chmod("+x", installPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/shellx-carvel/kind_test.go
+++ b/shellx-carvel/kind_test.go
@@ -1,0 +1,9 @@
+package shellx_carvel
+
+import "testing"
+
+func tryInstallKindCLI(t *testing.T) {
+	requireNoErr(t, installKindCLI())
+	requireNoErr(t, ls(EnvBinPathKind))
+	requireTrue(t, isNoErr(whichKind()))
+}

--- a/shellx-carvel/release.go
+++ b/shellx-carvel/release.go
@@ -7,8 +7,9 @@ import (
 
 // This file provides functions that cater to releasing a Carvel package
 
+// TODO: Should these be environment variables?
 func getDefaultReleaseDir() string {
-	return "package/release"
+	return getDefaultCarvelPackagingDir() + "/release"
 }
 
 func getDefaultPackageImgpkgDir() string {

--- a/shellx-carvel/release_test.go
+++ b/shellx-carvel/release_test.go
@@ -7,10 +7,12 @@ import (
 )
 
 func tryPackageRelease(t *testing.T) {
-	sourceDir := "tmp/source"
-	configDir := sourceDir + "/config"
+	sourceDir := "tmp/packaging/source"
+	releaseDir := "tmp/packaging/release"
 
-	releaseDir := "tmp/release"
+	// config related
+	configDir := sourceDir + "/config"
+	// release related
 	pkgRepoDir := releaseDir + "/packages"
 	pkgImgpkgDir := releaseDir + "/.imgpkg"
 	pkgDir := pkgRepoDir + "/" + getEnvTrimKey(EnvPackageName)

--- a/shellx-carvel/testutil_test.go
+++ b/shellx-carvel/testutil_test.go
@@ -23,7 +23,7 @@ func requireNoErr(t *testing.T, err error) {
 	if err == nil {
 		return
 	}
-	t.Fatal(err)
+	t.Fatalf("expected no err got %+v", err)
 }
 
 func requireTrue(t *testing.T, actual bool) {
@@ -37,7 +37,7 @@ func requireEqual(t *testing.T, expected, actual string) {
 	if expected == actual {
 		return
 	}
-	t.Fatalf("expected %s got %s", expected, actual)
+	t.Fatalf("expected %q got %q", expected, actual)
 }
 
 func requireContains(t *testing.T, actual, expectedSubStr string) {


### PR DESCRIPTION
This helps avoid missing local registry errors

Signed-off-by: AmitKumarDas <amitd2@vmware.com>