### PR TITLE
feat: update logic to use internal sh package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 local-bin/
 .idea/
 tmp/
+TODO.md

--- a/shellx-carvel/README.md
+++ b/shellx-carvel/README.md
@@ -1,13 +1,14 @@
 ## Golang scripting to manage releases
 - This codebase showcases use of Golang to script a project's release
-- Note: _Release management is done by Carvel_
+- Note: _Carvel is used to manage releases_
 
 - ## Motivation:
   - Goodness of bash coupled with correctness of Golang
   - Granular error handling
   - 100% unit tested
   - Modular code base
-  - Reduced bash & make spaghetti
+  - Several util functions with in-built env expansion
+  - Less `bash` & `make` spaghetti
 
 ## Test
 - `make`

--- a/shellx-carvel/app.go
+++ b/shellx-carvel/app.go
@@ -1,5 +1,7 @@
 package shellx_carvel
 
+import shx "carvel.shellx.dev/internal/sh"
+
 func verifyApplication() error {
 	if isNotEq(EnvTestCarvelRelease, "true") {
 		return nil
@@ -28,11 +30,18 @@ func createK8sArtifactsDir() error {
 }
 
 func createFilePackageRepo() error {
-	return file(joinPaths(EnvArtifactsPathK8s, EnvFilePackageRepository), packageRepositoryYML, 0644)
+	fullPath, pathErr := shx.JoinPaths(EnvArtifactsPathK8s, EnvFilePackageRepository)
+	if pathErr != nil {
+		return pathErr
+	}
+	return file(fullPath, packageRepositoryYML, 0644)
 }
 
 func deleteThenCreatePackageRepo() error {
-	pkgRepoFilePath := joinPaths(EnvArtifactsPathK8s, EnvFilePackageRepository)
-	_ = kubectl("delete", "-f", pkgRepoFilePath) // ignore error if any
-	return kubectl("create", "-f", pkgRepoFilePath)
+	fullPath, pathErr := shx.JoinPaths(EnvArtifactsPathK8s, EnvFilePackageRepository)
+	if pathErr != nil {
+		return pathErr
+	}
+	_ = kubectl("delete", "-f", fullPath) // ignore error if any
+	return kubectl("create", "-f", fullPath)
 }

--- a/shellx-carvel/app_test.go
+++ b/shellx-carvel/app_test.go
@@ -2,6 +2,7 @@ package shellx_carvel
 
 import "testing"
 
-func tryAppDeployment(t *testing.T) {
+func tryVerifyApplication(t *testing.T) {
+	requireNoErr(t, deployKappController())
 	requireNoErr(t, verifyApplication())
 }

--- a/shellx-carvel/bundle_test.go
+++ b/shellx-carvel/bundle_test.go
@@ -24,5 +24,5 @@ func tryAppBundleCreateAndPublish(t *testing.T) {
 	requireNoErr(t, publishAppBundle(sourceDir))
 	out, outErr := sh.Output("curl", format("%s:%s/v2/_catalog", EnvRegistryName, EnvRegistryPort))
 	requireNoErr(t, outErr)
-	requireContains(t, joinPaths("packages", EnvAppBundleName), out)
+	requireContains(t, mustJoinPaths("packages", EnvAppBundleName), out)
 }

--- a/shellx-carvel/docker.go
+++ b/shellx-carvel/docker.go
@@ -10,7 +10,7 @@ func setupRegistryAsLocalDockerContainer() error {
 		return nil
 	}
 	if err := docker("inspect", "-f", "{{.State.Running}}", EnvRegistryName); err != nil {
-		var envErr *sh.InvalidArgError // Note: Must be a pointer
+		var envErr *sh.InvalidEnvError // Note: Must be a pointer
 		if errors.As(err, &envErr) {
 			return err
 		}

--- a/shellx-carvel/internal/sh/util.go
+++ b/shellx-carvel/internal/sh/util.go
@@ -1,0 +1,140 @@
+package sh
+
+import (
+	"fmt"
+	"os"
+	"path"
+)
+
+// isAlphaNum reports whether the byte is an ASCII letter, number, or underscore
+//
+// Note: Borrowed from os package
+func isAlphaNum(c uint8) bool {
+	return c == '_' || '0' <= c && c <= '9' || 'a' <= c && c <= 'z' || 'A' <= c && c <= 'Z'
+}
+
+// isShellSpecialVar reports whether the character identifies a special
+// shell variable such as $*.
+//
+// Note: Borrowed from os package
+func isShellSpecialVar(c uint8) bool {
+	switch c {
+	case '*', '#', '$', '@', '!', '?', '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+		return true
+	}
+	return false
+}
+
+// getShellName returns the name that begins the string and the number of bytes
+// consumed to extract it. If the name is enclosed in {}, it's part of a ${}
+// expansion and two more bytes are needed than the length of the name.
+//
+// Note: Borrowed from os package
+func getShellName(s string) (string, int) {
+	switch {
+	case s[0] == '{':
+		if len(s) > 2 && isShellSpecialVar(s[1]) && s[2] == '}' {
+			return s[1:2], 3
+		}
+		// Scan to closing brace
+		for i := 1; i < len(s); i++ {
+			if s[i] == '}' {
+				if i == 1 {
+					return "", 2 // Bad syntax; eat "${}"
+				}
+				return s[1:i], i + 1
+			}
+		}
+		return "", 1 // Bad syntax; eat "${"
+	case isShellSpecialVar(s[0]):
+		return s[0:1], 1
+	}
+	// Scan alphanumerics.
+	var i int
+	for i = 0; i < len(s) && isAlphaNum(s[i]); i++ {
+	}
+	return s[:i], i
+}
+
+// ExpandEnvStrict replaces ${var} or $var in the string. It returns
+// error for invalid use of $ or env expansion returns empty
+//
+// Note: Borrowed from os.Expand
+func ExpandEnvStrict(s string) (string, error) {
+	var buf []byte
+	// ${} is all ASCII, so bytes are fine for this operation.
+	i := 0
+	for j := 0; j < len(s); j++ {
+		if s[j] == '$' && j+1 < len(s) {
+			if buf == nil {
+				buf = make([]byte, 0, 2*len(s))
+			}
+			buf = append(buf, s[i:j]...)
+			name, w := getShellName(s[j+1:])
+			if name == "" && w > 0 {
+				// Encountered invalid syntax
+				return "", &InvalidEnvError{
+					Context:     fmt.Sprintf("failed to expand [%s]", s),
+					InvalidEnvs: []string{s[j+1:]},
+				}
+			} else if name == "" {
+				// Valid syntax, but $ was not followed by a
+				// name. Leave the dollar character untouched.
+				buf = append(buf, s[j])
+			} else {
+				val, found := os.LookupEnv(name)
+				if !found {
+					return "", &InvalidEnvError{
+						Context:     fmt.Sprintf("failed to lookup [%s]", s),
+						InvalidEnvs: []string{name},
+					}
+				}
+				buf = append(buf, val...)
+			}
+			j += w
+			i = j + 1
+		}
+	}
+	if buf == nil {
+		return s, nil
+	}
+	return string(buf) + s[i:], nil
+}
+
+// ExpandAllStrict returns error if the provided data makes use of unset
+// environment variables
+func ExpandAllStrict(data ...string) ([]string, error) {
+	var invalid = make([]error, 0, len(data))
+	var expanded = make([]string, 0, len(data))
+	for _, d := range data {
+		exp, err := ExpandEnvStrict(d)
+		if err != nil {
+			invalid = append(invalid, err)
+			continue
+		}
+		expanded = append(expanded, exp)
+	}
+	if len(invalid) == 0 {
+		return expanded, nil
+	}
+	return nil, &MultiError{Errors: invalid}
+}
+
+func File(name, data string, perm os.FileMode) error {
+	expanded, err := ExpandAllStrict(name, data)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(expanded[0], []byte(expanded[1]), perm)
+}
+
+func JoinPaths(paths ...string) (string, error) {
+	if len(paths) == 0 {
+		return "", fmt.Errorf("no paths given")
+	}
+	expanded, err := ExpandAllStrict(paths...)
+	if err != nil {
+		return "", err
+	}
+	return path.Join(expanded...), nil
+}

--- a/shellx-carvel/internal/sh/util_test.go
+++ b/shellx-carvel/internal/sh/util_test.go
@@ -65,7 +65,7 @@ func TestFilterInvalidEnvs(t *testing.T) {
 
 	for _, s := range scenarios {
 		t.Run(s.name, func(t *testing.T) {
-			_, got := VerifyArgs(s.envs...)
+			_, got := ExpandAllStrict(s.envs...)
 			if s.isErr {
 				requireErr(t, got)
 			} else {

--- a/shellx-carvel/kind.go
+++ b/shellx-carvel/kind.go
@@ -1,8 +1,8 @@
 package shellx_carvel
 
 import (
+	shx "carvel.shellx.dev/internal/sh"
 	"fmt"
-	"github.com/magefile/mage/sh"
 )
 
 func installKindCLI() error {
@@ -46,11 +46,18 @@ func createKindClusterConfigForLocalRegistry() error {
 	if err := mkdir(EnvArtifactsPathKind); err != nil {
 		return err
 	}
-	return file(joinPaths(EnvArtifactsPathKind, EnvFileKindCluster), kindClusterLocalRegistryYML, 0644)
+	fullPath, pathErr := shx.JoinPaths(EnvArtifactsPathKind, EnvFileKindCluster)
+	if pathErr != nil {
+		return pathErr
+	}
+	return file(fullPath, kindClusterLocalRegistryYML, 0644)
 }
 
 func createKindCluster() error {
-	kindClusterFilePath := joinPaths(EnvArtifactsPathKind, EnvFileKindCluster)
+	kindClusterFilePath, pathErr := shx.JoinPaths(EnvArtifactsPathKind, EnvFileKindCluster)
+	if pathErr != nil {
+		return pathErr
+	}
 	if !exists(kindClusterFilePath) {
 		return fmt.Errorf("file %q not found", kindClusterFilePath)
 	}
@@ -72,13 +79,21 @@ func createKindNetwork() error {
 }
 
 func createKindConfigFileLocalRegistryHosting() error {
-	return file(joinPaths(EnvArtifactsPathKind, EnvFileKindConfigLocalRegistryHosting), kindConfigLocalRegistryHostingYML, 0644)
+	fullPath, pathErr := shx.JoinPaths(EnvArtifactsPathKind, EnvFileKindConfigLocalRegistryHosting)
+	if pathErr != nil {
+		return pathErr
+	}
+	return file(fullPath, kindConfigLocalRegistryHostingYML, 0644)
 }
 
 func applyKindConfigLocalRegistryHosting() error {
-	return kubectl("apply", "-f", joinPaths(EnvArtifactsPathKind, EnvFileKindConfigLocalRegistryHosting))
+	fullPath, pathErr := shx.JoinPaths(EnvArtifactsPathKind, EnvFileKindConfigLocalRegistryHosting)
+	if pathErr != nil {
+		return pathErr
+	}
+	return kubectl("apply", "-f", fullPath)
 }
 
 func printEtcHostsUpdateMsg() error {
-	return sh.RunV("echo", etcHostsUpdateMsg)
+	return shx.RunV("echo", etcHostsUpdateMsg)
 }

--- a/shellx-carvel/main_test.go
+++ b/shellx-carvel/main_test.go
@@ -9,5 +9,5 @@ func TestReleaseOfCarvelPackage(t *testing.T) {
 	tryAppBundleCreateAndPublish(t)
 	tryPackageRelease(t)
 	trySetupKindCluster(t)
-	tryAppDeployment(t)
+	tryVerifyApplication(t)
 }

--- a/shellx-carvel/release.go
+++ b/shellx-carvel/release.go
@@ -8,37 +8,37 @@ import (
 // This file provides functions that cater to releasing a Carvel package
 
 // TODO: Should these be environment variables?
-func getDefaultReleaseDir() string {
-	return joinPaths(getDefaultCarvelPackagingDir(), "release")
-}
-
-func getDefaultPackageImgpkgDir() string {
-	return joinPaths(getDefaultReleaseDir(), ".imgpkg")
-}
-
-func getDefaultPackageRepoDir() string {
-	return joinPaths(getDefaultReleaseDir(), "packages")
-}
-
-func getDefaultPackageDir() string {
-	return joinPaths(getDefaultPackageRepoDir(), EnvPackageName)
-}
-
-func getDefaultPackageMetadataFile() string {
-	return joinPaths(getDefaultPackageDir(), "package-metadata.yml")
-}
-
-func getDefaultPackageTemplateFile() string {
-	return joinPaths(getDefaultPackageDir(), "package-template.yml")
-}
-
-func getDefaultPackageVersionFile() string {
-	return joinPaths(getDefaultPackageDir(), EnvPackageVersion+".yml")
-}
-
-func getDefaultPackageImgpkgFile() string {
-	return joinPaths(getDefaultPackageImgpkgDir(), "images.yml")
-}
+//func getDefaultReleaseDir() string {
+//	return joinPaths(getDefaultCarvelPackagingDir(), "release")
+//}
+//
+//func getDefaultPackageImgpkgDir() string {
+//	return joinPaths(getDefaultReleaseDir(), ".imgpkg")
+//}
+//
+//func getDefaultPackageRepoDir() string {
+//	return joinPaths(getDefaultReleaseDir(), "packages")
+//}
+//
+//func getDefaultPackageDir() string {
+//	return joinPaths(getDefaultPackageRepoDir(), EnvPackageName)
+//}
+//
+//func getDefaultPackageMetadataFile() string {
+//	return joinPaths(getDefaultPackageDir(), "package-metadata.yml")
+//}
+//
+//func getDefaultPackageTemplateFile() string {
+//	return joinPaths(getDefaultPackageDir(), "package-template.yml")
+//}
+//
+//func getDefaultPackageVersionFile() string {
+//	return joinPaths(getDefaultPackageDir(), EnvPackageVersion+".yml")
+//}
+//
+//func getDefaultPackageImgpkgFile() string {
+//	return joinPaths(getDefaultPackageImgpkgDir(), "images.yml")
+//}
 
 func createReleaseDirs(pkgDir, pkgImgpkgDir string) error {
 	if err := mkdir(pkgDir); err != nil {

--- a/shellx-carvel/release_test.go
+++ b/shellx-carvel/release_test.go
@@ -40,7 +40,5 @@ func tryPackageRelease(t *testing.T) {
 	requireNoErr(t, publishPackageRepoBundle(releaseDir))
 	out, outErr := sh.Output("curl", format("%s:%s/v2/_catalog", EnvRegistryName, EnvRegistryPort))
 	requireNoErr(t, outErr)
-	requireContains(t, joinPaths("packages", EnvPackageRepoName), out)
-
-	requireNoErr(t, deployKappController())
+	requireContains(t, mustJoinPaths("packages", EnvPackageRepoName), out)
 }

--- a/shellx-carvel/runtime.go
+++ b/shellx-carvel/runtime.go
@@ -2,7 +2,6 @@ package shellx_carvel
 
 import (
 	shx "carvel.shellx.dev/internal/sh"
-	"github.com/magefile/mage/sh"
 	"runtime"
 )
 
@@ -53,19 +52,16 @@ var binPathCarvel = maybeSetEnv(EnvBinPathCarvel, "tmp")
 var binPathKind = maybeSetEnv(EnvBinPathKind, "tmp")
 
 // Carvel binaries / CLIs as functions
-var kbld = shx.RunCmdStrict(binPathCarvel + "/kbld")
-var whichKbld = shx.RunCmdStrict("ls", binPathCarvel+"/kbld")
-var imgpkg = shx.RunCmdStrict(binPathCarvel + "/imgpkg")
-var whichImgpkg = shx.RunCmdStrict("ls", binPathCarvel+"/imgpkg")
-var ytt = shx.RunCmdStrict(binPathCarvel + "/ytt")
-var whichYtt = shx.RunCmdStrict("ls", binPathCarvel+"/ytt")
+var kbld = shx.RunCmd(binPathCarvel + "/kbld")
+var whichKbld = shx.RunCmd("ls", binPathCarvel+"/kbld")
+var imgpkg = shx.RunCmd(binPathCarvel + "/imgpkg")
+var whichImgpkg = shx.RunCmd("ls", binPathCarvel+"/imgpkg")
+var ytt = shx.RunCmd(binPathCarvel + "/ytt")
+var whichYtt = shx.RunCmd("ls", binPathCarvel+"/ytt")
 
 // KIND CLI as function
-var kind = shx.RunCmdStrict(binPathKind + "/kind")
-var whichKind = shx.RunCmdStrict("ls", binPathKind+"/kind")
-
-// kubectl cli as function
-var kubectl = shx.RunCmdStrict("kubectl")
+var kind = shx.RunCmd(binPathKind + "/kind")
+var whichKind = shx.RunCmd("ls", binPathKind+"/kind")
 
 func init() {
 	const (
@@ -124,5 +120,5 @@ func init() {
 	}
 
 	// display all the environment variables for debuggability
-	sh.RunV("env")
+	_ = shx.RunV("env")
 }

--- a/shellx-carvel/testutil_test.go
+++ b/shellx-carvel/testutil_test.go
@@ -1,6 +1,7 @@
 package shellx_carvel
 
 import (
+	shx "carvel.shellx.dev/internal/sh"
 	"strings"
 	"testing"
 )
@@ -45,4 +46,12 @@ func requireContains(t *testing.T, expectedSubStr, actual string) {
 		return
 	}
 	t.Fatalf("expected substring %q is not part of actual %q", expectedSubStr, actual)
+}
+
+func mustJoinPaths(paths ...string) string {
+	finalPath, err := shx.JoinPaths(paths...)
+	if err != nil {
+		panic(err)
+	}
+	return finalPath
 }

--- a/shellx-carvel/util.go
+++ b/shellx-carvel/util.go
@@ -1,24 +1,26 @@
 package shellx_carvel
 
 import (
-	"carvel.shellx.dev/internal/sh"
+	shx "carvel.shellx.dev/internal/sh"
 	"fmt"
 	"os"
-	"path"
 	"strings"
 )
 
 // Unix & generic commands as functions
-var mkdir = sh.RunCmdStrict("mkdir", "-p")
-var curl = sh.RunCmdStrict("curl")
-var ls = sh.RunCmdStrict("ls")
-var chmod = sh.RunCmdStrict("chmod")
+var mkdir = shx.RunCmd("mkdir", "-p")
+var curl = shx.RunCmd("curl")
+var ls = shx.RunCmd("ls")
+var chmod = shx.RunCmd("chmod")
 
 // Docker CLI as function
-var docker = sh.RunCmdStrict("docker")
+var docker = shx.RunCmd("docker")
+
+// kubectl CLI as function
+var kubectl = shx.RunCmd("kubectl")
 
 // File creation as a function
-var file = sh.File
+var file = shx.File
 
 // passThroughFn returns the provided input. It is useful
 // as a custom mapper function for os.Expand
@@ -32,7 +34,7 @@ func maybeSetEnv(envKey, defaultVal string) string {
 		// envKey is first expanded such that "$key" or "${key}" if any
 		// is trimmed to produce "key" & then this trimmed key is
 		// set as an environment variable
-		os.Setenv(os.Expand(envKey, passThroughFn), defaultVal)
+		_ = os.Setenv(os.Expand(envKey, passThroughFn), defaultVal)
 	}
 	return os.ExpandEnv(envKey)
 }
@@ -43,14 +45,6 @@ func getEnv(envKey string) string {
 
 func exists(file string) bool {
 	return ls(file) == nil
-}
-
-func joinPaths(elem ...string) string {
-	var out = make([]string, len(elem))
-	for _, i := range elem {
-		out = append(out, getEnv(i))
-	}
-	return path.Join(out...)
 }
 
 func isErr(err error, more ...error) bool {


### PR DESCRIPTION
This change ensures logic detects env mistakes and reports them as errors. Since mage's sh package is not strict about missing env lookups, internal sh package borrows most of mage's sh codebase and makes them stricter.

Signed-off-by: AmitKumarDas <amitd2@vmware.com>